### PR TITLE
Fix the base.siteurl when present

### DIFF
--- a/build/jekyll_lunr_js_search.rb
+++ b/build/jekyll_lunr_js_search.rb
@@ -69,7 +69,7 @@ module Jekyll
           doc = {
             "id" => i,
             "title" => entry.title,
-            "url" => entry.url,
+            "url" => site.baseurl + entry.url,
             "date" => entry.date,
             "categories" => entry.categories,
             "body" => entry.body

--- a/lib/jekyll_lunr_js_search/indexer.rb
+++ b/lib/jekyll_lunr_js_search/indexer.rb
@@ -69,7 +69,7 @@ module Jekyll
           doc = {
             "id" => i,
             "title" => entry.title,
-            "url" => entry.url,
+            "url" => site.baseurl + entry.url,
             "date" => entry.date,
             "categories" => entry.categories,
             "body" => entry.body


### PR DESCRIPTION
When `site.baseurl` is present, search results are not linked correctly. This PR address that.
