### PR TITLE
Posts have been removed in Jekyll 3.x.

### DIFF
--- a/lib/jekyll_lunr_js_search/indexer.rb
+++ b/lib/jekyll_lunr_js_search/indexer.rb
@@ -130,7 +130,11 @@ module Jekyll
         
         # deep copy pages
         site.pages.each {|page| items << page.dup }
-        site.posts.each {|post| items << post.dup }
+        if defined?(site.posts.docs)
+          site.posts.docs.each {|post| items << post.dup }
+        else
+          site.posts.each {|post| items << post.dup }
+        end
         site.documents.each {|document| items << document.dup }
 
         # only process files that will be converted to .html and only non excluded files 

--- a/lib/jekyll_lunr_js_search/search_entry.rb
+++ b/lib/jekyll_lunr_js_search/search_entry.rb
@@ -5,14 +5,16 @@ module Jekyll
     class SearchEntry
       def self.create(page_or_post, renderer)
         case page_or_post
-        when Jekyll::Post
-          date = page_or_post.date
-          categories = page_or_post.categories
         when Jekyll::Page, Jekyll::Document
           date = nil
           categories = []
         else 
-          raise 'Not supported'
+          if defined?(Jekyll::Post) and page_or_post.is_a?(Jekyll::Post)
+            date = page_or_post.date
+            categories = page_or_post.categories
+          else
+            raise 'Not supported'
+          end
         end
         title, url = extract_title_and_url(page_or_post)
         body = renderer.render(page_or_post)


### PR DESCRIPTION
In 3.x, posts have become documents. But we still want to handle posts in Jekyll 2.x and earlier, since documents at those times don't have a ton of information (e.g. no date).

Additionally in Jekyll 3.x, you must loop on `site.posts.docs` to avoid a deprecation error, so we use that if it's available.

Sorry if this doesn't feel like very idiomatic Ruby--this is probably the most Ruby coding I've done in one session to date! But Jekyll 3.x has otherwise broken the lunr-js-search plugin for us, and I'm sure it's broken for others as well.