### PR TITLE
This fixes slashdotdash/jekyll-lunr-js-search#88

### DIFF
--- a/lib/jekyll_lunr_js_search/search_entry.rb
+++ b/lib/jekyll_lunr_js_search/search_entry.rb
@@ -6,7 +6,11 @@ module Jekyll
       def self.create(page_or_post, renderer)
         case page_or_post
         when Jekyll::Page, Jekyll::Document
-          date = nil
+          if defined?(page_or_post.date)
+            date = page_or_post.date
+          else
+            date = nil
+          end
           categories = []
         else 
           if defined?(Jekyll::Post) and page_or_post.is_a?(Jekyll::Post)


### PR DESCRIPTION
Jekyll 3.0.1 doesn't seem to have Jekyll::Post class defined. Added a check for the date variable on pages and documents. This seems to resolve the problem.