### PR TITLE
Force no layout, cause jekyll supports default ones.

### DIFF
--- a/lib/jekyll_lunr_js_search/page_renderer.rb
+++ b/lib/jekyll_lunr_js_search/page_renderer.rb
@@ -11,7 +11,7 @@ module Jekyll
       def prepare(item)
         layout = item.data["layout"]
         begin
-          item.data.delete("layout")
+          item.data["layout"] = nil
 
           if item.is_a?(Jekyll::Document)          
             output = Jekyll::Renderer.new(@site, item).run


### PR DESCRIPTION
Force a `null` layout when rendering a page.
Having a default layout for the whole site breaks this and navbar or headers get indexed too.
This ensures we are indexing only the content.
