### PR TITLE
Adding hook

### DIFF
--- a/js/jquery.lunr.search.js
+++ b/js/jquery.lunr.search.js
@@ -30,6 +30,7 @@
       this.template = this.compileTemplate($(options.template));
       this.titleMsg = options.titleMsg;
       this.emptyMsg = options.emptyMsg;
+      this.onAfterResultShow = options.onAfterResultShow;
 
       this.initialize();
     }
@@ -107,6 +108,7 @@
         });
 
         this.displayResults(results);
+        this.onAfterResultShow();
       }
     };
 
@@ -156,6 +158,7 @@
     results   : '#search-results',          // selector for containing search results element
     template  : '#search-results-template', // selector for Mustache.js template
     titleMsg  : '<h1>Search results<h1>',   // message attached in front of results
-    emptyMsg  : '<p>Nothing found.</p>'     // shown message if search returns no results
+    emptyMsg  : '<p>Nothing found.</p>',    // shown message if search returns no results
+    onAfterResultShow: function() {}        // a hook to process the page after the search results have been shown
   };
 })(jQuery);


### PR DESCRIPTION
Since the search and population of the template is async, it's difficult to modify the page any further. I've added a hook which runs after the results are shown. Now you can do something like this:

```js
$('#search-query').lunrSearch({
    indexUrl  : '/lunr/index.json',
    results   : '#search-results',
    template  : '#search-results-template',
    titleMsg  : '<div class="search-results-message"><h3>Search results<h3></div>',
    emptyMsg  : '<div class="search-results-message"><h3>Nothing found!</h3><div><p>Show <a href="/search/?q=">all posts</a>.</p></div></div>',
    onAfterResultShow : function() {
      $().updateShareCounts();
    }
  });
```